### PR TITLE
Add force install flag and improve package search

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -57,11 +57,14 @@ pub struct RunArguments {
 }
 
 #[derive(Debug, Args)]
-#[command(group = clap::ArgGroup::new("sources").required(true).multiple(false))]
+#[command(group = clap::ArgGroup::new("sources").required(true).multiple(true))]
 pub struct InstallArguments {
     /// Path to your shell script project, or a url to a shell script project git repository
     #[arg(group = "sources")]
     pub path: String,
+    /// Force to install the package, or perform an update. Use `-F` for short.
+    #[arg(short = 'F', long, group = "sources", default_value_t = false)]
+    pub force: bool,
 }
 
 #[derive(Debug, Parser)]

--- a/src/display_control.rs
+++ b/src/display_control.rs
@@ -1,3 +1,6 @@
+use std::io::Write;
+
+use anyhow::{Error, Result};
 use console::{style, Term};
 use prettytable::{Cell, Row, Table};
 
@@ -46,4 +49,16 @@ pub fn display_form(column_labels: Vec<&str>, rows: &Vec<Vec<String>>) {
     }
 
     table.printstd();
+}
+
+pub fn input_message(prompt: &str) -> Result<String, Error> {
+    // display the prompt message for inputting values
+    display_message(Level::Input, prompt);
+    // collect the input as a string
+    let mut input = String::new();
+    // receive stdin
+    std::io::stdout().flush()?;
+    std::io::stdin().read_line(&mut input)?;
+
+    Ok(input)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,43 +8,33 @@ use std::path::{Path, PathBuf};
 
 use arguments::{Arguments, Commands};
 use clap::{Parser, crate_version};
-use console::Term;
 
+use display_control::display_message;
 use package::{Package, PackageManager};
 use utilities::{execute_run_command, show_packages};
 
 fn main() {
-    // Create a terminal display
-    let terminal: Term = Term::stdout();
     // Parse command line arguments
-    let arguments = Arguments::parse();
+    let arguments: Arguments = Arguments::parse();
     // Initialize a package manager
-    let package_manager = match PackageManager::new() {
+    let package_manager: PackageManager = match PackageManager::new() {
         Ok(result) => result,
         Err(error) => {
-            terminal
-                .write_line(&format!("{}", error.to_string()))
-                .unwrap();
+            display_message(display_control::Level::Error, &format!("{}", error.to_string()));
             return;
         }
     };
 
     // Map the arguments to corresponding code logics
     match arguments.commands {
-        Commands::Run(subcommand) => match execute_run_command(subcommand.expression) {
+        Commands::Run(subcommand) => match execute_run_command(&package_manager, subcommand.expression) {
             Ok(_) => {}
-            Err(error) => terminal
-                .write_line(&format!("{}", error.to_string()))
-                .unwrap(),
+            Err(error) => display_message(display_control::Level::Error, &format!("{}", error.to_string())),
         },
         Commands::Install(subcommand) => {
-            match package_manager.install_package(Path::new(&subcommand.path), false) {
-                Ok(_) => terminal
-                    .write_line("Package installation succeeded.")
-                    .unwrap(),
-                Err(error) => terminal
-                    .write_line(&format!("{}", error.to_string()))
-                    .unwrap(),
+            match package_manager.install_package(Path::new(&subcommand.path), false, subcommand.force) {
+                Ok(_) => display_message(display_control::Level::Logging, "Package installation succeeded."),
+                Err(error) => display_message(display_control::Level::Error, &format!("{}", error.to_string())),
             }
         }
         Commands::List(_) => {
@@ -53,47 +43,32 @@ fn main() {
                     show_packages(&packages_metadata);
                 },
                 Err(error) => {
-                    terminal
-                        .write_line(&format!("Error retrieving installed packages: {}", error.to_string()))
-                        .unwrap();
-                    return;
+                    display_message(display_control::Level::Error, &format!("Error retrieving installed packages: {}", error.to_string()));
                 }
             };
         }
         Commands::Uninstall(subcommand) => {
             match package_manager.uninstall_package_by_name(subcommand.expression) {
-                Ok(_) => terminal
-                    .write_line("Package uninstalled successfully.")
-                    .unwrap(),
-                Err(error) => terminal
-                    .write_line(&format!("Error uninstalling package: {}", error.to_string()))
-                    .unwrap(),
+                Ok(_) => display_message(display_control::Level::Logging, "Package uninstalled successfully."),
+                Err(error) => display_message(display_control::Level::Error, &format!("Error uninstalling package: {}", error.to_string())),
             }
         }
         Commands::Check(_) => {
-            terminal
-                .write_line("The 'Check' feature is still under development.")
-                .unwrap();
+            display_message(display_control::Level::Logging, "The 'Check' feature is still under development.");
         }
         Commands::New(subcommand) => {
             let working_directory: PathBuf = Path::new("./").join(&subcommand.name);
             match std::fs::create_dir(&working_directory) {
                 Ok(_) => {}
-                Err(error) => terminal
-                    .write_line(&format!("{}", error.to_string()))
-                    .unwrap(),
+                Err(error) => display_message(display_control::Level::Error, &format!("{}", error.to_string())),
             };
 
             match package_manager.create_package(
                 working_directory.as_path(),
                 &Package::new(subcommand.name, subcommand.lib),
             ) {
-                Ok(_) => terminal
-                    .write_line("Package created successfully.")
-                    .unwrap(),
-                Err(error) => terminal
-                    .write_line(&format!("{}", error.to_string()))
-                    .unwrap(),
+                Ok(_) => display_message(display_control::Level::Logging, "Package created successfully."),
+                Err(error) => display_message(display_control::Level::Error, &format!("{}", error.to_string())),
             };
         }
         Commands::Init(subcommand) => {
@@ -111,16 +86,12 @@ fn main() {
                     subcommand.lib,
                 ),
             ) {
-                Ok(_) => terminal
-                    .write_line("Package created successfully.")
-                    .unwrap(),
-                Err(error) => terminal
-                    .write_line(&format!("{}", error.to_string()))
-                    .unwrap(),
+                Ok(_) => display_message(display_control::Level::Logging, "Package created successfully."),
+                Err(error) => display_message(display_control::Level::Error, &format!("{}", error.to_string())),
             };
         }
         Commands::Version(_) => {
-            terminal.write_line(&format!("cchain version: {}", crate_version!())).unwrap();
+            display_message(display_control::Level::Logging, &format!("Shell Package Manager (spm) version: {}", crate_version!()));
         }
     }
 

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -1,12 +1,12 @@
 use std::path::Path;
 
-use anyhow::{Error, Result};
+use anyhow::{anyhow, Error, Result};
 
 use crate::{
-    display_control::display_form, package::{is_inside_a_package, Package, PackageMetadata}, shell::execute_shell_script
+    display_control::{display_form, display_message, display_tree_message, input_message, Level}, package::{is_inside_a_package, Package, PackageManager, PackageMetadata}, shell::execute_shell_script
 };
 
-pub fn execute_run_command(expression: String) -> Result<(), Error> {
+pub fn execute_run_command(package_manager: &PackageManager, expression: String) -> Result<(), Error> {
     let path: &Path = Path::new(&expression);
 
     // Case 1: input is a shell script
@@ -33,8 +33,38 @@ pub fn execute_run_command(expression: String) -> Result<(), Error> {
     }
 
     // Case 3: Input is a keyword or keywords
-
-    Ok(())
+    let package_candidates: Vec<PackageMetadata> = package_manager.keyword_search(&expression)?;
+    // Throw an error if no chains are found
+    if package_candidates.len() == 0 {
+        return Err(anyhow!("No packages found"));
+    }
+    
+    // Run the chain if it is exactly one
+    if package_candidates.len() == 1 {
+        return execute_shell_script(
+            &path
+                .join(package_candidates[0].get_main_entry_point())
+                .canonicalize()
+                .unwrap()
+                .to_string_lossy()
+                .to_string(),
+        );
+    }
+    
+    display_message(Level::Logging, "Multiple packages found:");
+    for (index, package_metadata) in package_candidates.iter().enumerate() {
+        display_tree_message(1, &format!("{}: {}", index + 1, package_metadata.get_pacakge_name()));
+    }
+    let selection: usize = input_message("Please select a chain to execute:")?.trim().parse::<usize>()?;
+    
+    return execute_shell_script(
+        &path
+            .join(package_candidates[selection - 1].get_main_entry_point())
+            .canonicalize()
+            .unwrap()
+            .to_string_lossy()
+            .to_string(),
+    );
 }
 
 pub fn show_packages(packages_metadata: &Vec<PackageMetadata>) {


### PR DESCRIPTION
- Add `--force` (-F) flag to InstallArguments for forced install/update
- Implement keyword search for package execution
- Add input_message utility for user prompts
- Normalize package names for better search matching
- Improve error handling with display_control module
- Add get_main_entry_point method to PackageMetadata