### PR TITLE
Add interpreter option for package creation and execution

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -7,6 +7,8 @@ use clap::{
     crate_authors, crate_description, crate_version,
 };
 
+use crate::shell::ShellType;
+
 // Configures Clap v3-style help menu colors
 const STYLES: Styles = Styles::styled()
     .header(AnsiColor::Green.on_default().effects(Effects::BOLD))
@@ -94,6 +96,12 @@ pub struct NewArguments {
     /// it will be a template file.
     #[arg(group = "sources")]
     pub name: String,
+    // Specify the interpreter to use.
+    // In UNIX-like system, `sh` is the default.
+    // In Windows, `cmd` is the default.
+    // Currently support: `sh`, `bash`, `zsh`, `cmd`.
+    #[arg(short = 'I', long, group = "sources", default_value = "sh")]
+    pub interpreter: String,
     // If specified, the project will be a library.
     // Otherwise, it is an executable program.
     #[arg(short, long, group = "sources", default_value_t = false)]
@@ -111,6 +119,12 @@ pub struct InitializeArguments {
     // Otherwise, it is an executable program.
     #[arg(short, long, group = "sources", default_value_t = false)]
     pub lib: bool,
+    // Specify the interpreter to use.
+    // In UNIX-like system, `sh` is the default.
+    // In Windows, `cmd` is the default.
+    // Currently support: `sh`, `bash`, `zsh`, `cmd`.
+    #[arg(short = 'I', long, group = "sources", default_value = "sh")]
+    pub interpreter: String,
 }
 
 #[derive(Debug, Args)]

--- a/src/display_control.rs
+++ b/src/display_control.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use anyhow::{Error, Result};
-use console::{style, Term};
+use console::{Term, style};
 use prettytable::{Cell, Row, Table};
 
 #[derive(Debug, Clone, Copy)]
@@ -10,15 +10,15 @@ pub enum Level {
     Error,
     Warn,
     Selection,
-    Input
+    Input,
 }
 
 pub fn display_command_line(terminal: &Term, message: &str) {
     let indentation: String = "    ".to_string();
     for line in message.lines() {
-        terminal.write_line(
-            &format!("{}{}", indentation, style(line).dim())
-        ).unwrap();
+        terminal
+            .write_line(&format!("{}{}", indentation, style(line).dim()))
+            .unwrap();
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ fn main() {
 
             match package_manager.create_package(
                 working_directory.as_path(),
-                &Package::new(subcommand.name, subcommand.lib),
+                &Package::new(subcommand.name, subcommand.lib, subcommand.interpreter.into()),
             ) {
                 Ok(_) => display_message(display_control::Level::Logging, "Package created successfully."),
                 Err(error) => display_message(display_control::Level::Error, &format!("{}", error.to_string())),
@@ -84,6 +84,7 @@ fn main() {
                         .to_string_lossy()
                         .to_string(),
                     subcommand.lib,
+                    subcommand.interpreter.into()
                 ),
             ) {
                 Ok(_) => display_message(display_control::Level::Logging, "Package created successfully."),

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -1,12 +1,17 @@
 use std::path::Path;
 
-use anyhow::{anyhow, Error, Result};
+use anyhow::{Error, Result, anyhow};
 
 use crate::{
-    display_control::{display_form, display_message, display_tree_message, input_message, Level}, package::{is_inside_a_package, Package, PackageManager, PackageMetadata}, shell::execute_shell_script
+    display_control::{Level, display_form, display_message, display_tree_message, input_message},
+    package::{Package, PackageManager, PackageMetadata, is_inside_a_package},
+    shell::execute_shell_script,
 };
 
-pub fn execute_run_command(package_manager: &PackageManager, expression: String) -> Result<(), Error> {
+pub fn execute_run_command(
+    package_manager: &PackageManager,
+    expression: String,
+) -> Result<(), Error> {
     let path: &Path = Path::new(&expression);
 
     // Case 1: input is a shell script
@@ -38,7 +43,7 @@ pub fn execute_run_command(package_manager: &PackageManager, expression: String)
     if package_candidates.len() == 0 {
         return Err(anyhow!("No packages found"));
     }
-    
+
     // Run the chain if it is exactly one
     if package_candidates.len() == 1 {
         return execute_shell_script(
@@ -50,13 +55,18 @@ pub fn execute_run_command(package_manager: &PackageManager, expression: String)
                 .to_string(),
         );
     }
-    
+
     display_message(Level::Logging, "Multiple packages found:");
     for (index, package_metadata) in package_candidates.iter().enumerate() {
-        display_tree_message(1, &format!("{}: {}", index + 1, package_metadata.get_pacakge_name()));
+        display_tree_message(
+            1,
+            &format!("{}: {}", index + 1, package_metadata.get_pacakge_name()),
+        );
     }
-    let selection: usize = input_message("Please select a chain to execute:")?.trim().parse::<usize>()?;
-    
+    let selection: usize = input_message("Please select a chain to execute:")?
+        .trim()
+        .parse::<usize>()?;
+
     return execute_shell_script(
         &path
             .join(package_candidates[selection - 1].get_main_entry_point())


### PR DESCRIPTION
- Add `interpreter` field to `NewArguments` and `InitializeArguments`
- Support `sh`, `bash`, `zsh`, `cmd` interpreters with default `sh`
- Enhance `ShellType` with shebang generation and string conversion
- Update package creation to use specified interpreter in scripts
- Improve code formatting and organization in multiple files