### PR TITLE
Make shell script path optional with default to current directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ on:
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
       tag: ${{ !github.event.pull_request && github.ref_name || '' }}
@@ -168,7 +168,7 @@ jobs:
     needs:
       - plan
       - build-local-artifacts
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
@@ -218,7 +218,7 @@ jobs:
     if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
@@ -282,7 +282,7 @@ jobs:
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
     if: ${{ always() && needs.host.result == 'success' }}
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ on:
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
-    runs-on: "depot-ubuntu-latest-4"
+    runs-on: "ubuntu-20.04"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
       tag: ${{ !github.event.pull_request && github.ref_name || '' }}
@@ -168,7 +168,7 @@ jobs:
     needs:
       - plan
       - build-local-artifacts
-    runs-on: "depot-ubuntu-latest-4"
+    runs-on: "ubuntu-20.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
@@ -218,7 +218,7 @@ jobs:
     if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: "depot-ubuntu-latest-4"
+    runs-on: "ubuntu-20.04"
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
@@ -282,7 +282,7 @@ jobs:
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
     if: ${{ always() && needs.host.result == 'success' }}
-    runs-on: "depot-ubuntu-latest-4"
+    runs-on: "ubuntu-20.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ on:
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
-    runs-on: "ubuntu-22.04"
+    runs-on: "depot-ubuntu-latest-4"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
       tag: ${{ !github.event.pull_request && github.ref_name || '' }}
@@ -168,7 +168,7 @@ jobs:
     needs:
       - plan
       - build-local-artifacts
-    runs-on: "ubuntu-20.04"
+    runs-on: "depot-ubuntu-latest-4"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
@@ -218,7 +218,7 @@ jobs:
     if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: "ubuntu-20.04"
+    runs-on: "depot-ubuntu-latest-4"
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
@@ -282,7 +282,7 @@ jobs:
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
     if: ${{ always() && needs.host.result == 'success' }}
-    runs-on: "ubuntu-20.04"
+    runs-on: "depot-ubuntu-latest-4"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -17,4 +17,4 @@ install-path = "CARGO_HOME"
 install-updater = true
 
 [dist.github-custom-runners]
-global = "depot-ubuntu-latest-4"
+runner = "ubuntu-latest"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -15,3 +15,6 @@ targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-pc-wind
 install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = true
+
+[dist.github-custom-runners]
+global = "depot-ubuntu-latest-4"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -17,4 +17,4 @@ install-path = "CARGO_HOME"
 install-updater = true
 
 [dist.github-custom-runners]
-runner = "ubuntu-latest"
+global = "ubuntu-latest"

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -7,8 +7,6 @@ use clap::{
     crate_authors, crate_description, crate_version,
 };
 
-use crate::shell::ShellType;
-
 // Configures Clap v3-style help menu colors
 const STYLES: Styles = Styles::styled()
     .header(AnsiColor::Green.on_default().effects(Effects::BOLD))
@@ -49,12 +47,12 @@ pub enum Commands {
 }
 
 #[derive(Debug, Args)]
-#[command(group = clap::ArgGroup::new("sources").required(true).multiple(false))]
+#[command(group = clap::ArgGroup::new("sources").required(false).multiple(false))]
 pub struct RunArguments {
-    /// Index of the shell script, or a path to a shell script, or keyword(s) of a shell script.
+    /// A path to a shell script, or keyword(s) of a shell script.
     /// Single keyword: `spm run keyword1`.
     /// Multiple keywords: `spm run "keyword1 keyword2"`.
-    #[arg(group = "sources")]
+    #[arg(group = "sources", default_value = ".")]
     pub expression: String,
 }
 

--- a/src/package.rs
+++ b/src/package.rs
@@ -229,6 +229,14 @@ impl PackageManager {
                 if package_words.is_empty() {
                     continue;
                 }
+                
+                // If exactly matches the input and the package name
+                if &package.package_json_content.name == keywords {
+                    matched_packages.push((package.clone(), 1));
+                }
+                if package_name == keywords {
+                    matched_packages.push((package.clone(), 1));
+                }
 
                 for word in words.iter() {
                     // Skip if the keyword is empty

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -37,8 +37,8 @@ pub fn execute_run_command(
                     .to_string(),
             );
         }
-    }
-
+    } 
+    
     // Case 3: Input is a keyword or keywords
     let package_candidates: Vec<PackageMetadata> = package_manager.keyword_search(&expression)?;
     // Throw an error if no chains are found


### PR DESCRIPTION
- Remove unused ShellType import
- Change RunArguments sources group to be optional
- Set default expression value to "."
- Clean up execute_run_command whitespace
- Fixed a bug: if the package name is something like `test_2`, and `spm run test_2` won't find the package. Add a case to handle the exact match. 